### PR TITLE
Better concurrency support

### DIFF
--- a/src/com/activeandroid/ActiveAndroid.java
+++ b/src/com/activeandroid/ActiveAndroid.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.activeandroid.util.Log;
+import android.os.Build;
 
 public final class ActiveAndroid {
 	//////////////////////////////////////////////////////////////////////////////////////
@@ -60,8 +61,16 @@ public final class ActiveAndroid {
 		return Cache.openDatabase();
 	}
 
+    /**
+     * Non-exclusive transactions allows BEGIN IMMEDIATE
+     * blocks, allowing better read concurrency.
+     */
 	public static void beginTransaction() {
-		Cache.openDatabase().beginTransaction();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+            Cache.openDatabase().beginTransaction();
+        } else {
+            Cache.openDatabase().beginTransactionNonExclusive();
+        }
 	}
 
 	public static void endTransaction() {

--- a/src/com/activeandroid/DatabaseHelper.java
+++ b/src/com/activeandroid/DatabaseHelper.java
@@ -37,6 +37,7 @@ import com.activeandroid.util.Log;
 import com.activeandroid.util.NaturalOrderComparator;
 import com.activeandroid.util.SQLiteUtils;
 import com.activeandroid.util.SqlParser;
+import android.os.Build;
 
 public final class DatabaseHelper extends SQLiteOpenHelper {
 	//////////////////////////////////////////////////////////////////////////////////////
@@ -64,6 +65,25 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
 	//////////////////////////////////////////////////////////////////////////////////////
 	// OVERRIDEN METHODS
 	//////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * onConfigure is called when the db connection
+     * is being configured. It's the right place
+     * to enable write-ahead logging or foreign
+     * key support.
+     *
+     * Available for API level 16 (JellyBean) and above.
+     */
+    @Override
+    public void onConfigure(SQLiteDatabase db) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            db.enableWriteAheadLogging();
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            db.setForeignKeyConstraintsEnabled(true);
+        }
+        executePragmas(db);
+    }
 
 	@Override
 	public void onOpen(SQLiteDatabase db) {


### PR DESCRIPTION
DB concurrency is tricky in Android. The following changes
allow a better handling of multithreaded db access:
- Write ahead logging is enabled
- Connection is configured in onConfigure (SQLiteOpenHelper)
- Transactions are made in non-exclusive mode

References:
- http://developer.android.com/reference/android/database/sqlite/SQLiteDatabase.html#enableWriteAheadLogging()
- http://developer.android.com/reference/android/database/sqlite/SQLiteOpenHelper.html#onConfigure(android.database.sqlite.SQLiteDatabase)
- http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/4.0.1_r1/android/database/sqlite/SQLiteDatabase.java#SQLiteDatabase.beginTransaction%28android.database.sqlite.SQLiteTransactionListener%2Cboolean%29
- https://www.sqlite.org/lockingv3.html#reserved_lock
- https://www.sqlite.org/lang_transaction.html
- http://developer.android.com/reference/android/database/sqlite/SQLiteDatabase.html#beginTransactionNonExclusive()
